### PR TITLE
fix:サーバーのモデレーター以外にチャンネル編集権限がなくなってしまっていた問題を修正 #17

### DIFF
--- a/packages/backend/src/server/api/endpoints/channels/update.ts
+++ b/packages/backend/src/server/api/endpoints/channels/update.ts
@@ -102,11 +102,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 
 			const iAmModerator = await this.roleService.isModerator(me);
 
-			if (ps.collaboratorIds && channel.userId !== me.id && !iAmModerator) {
-				throw new ApiError(meta.errors.accessDenied);
-			}
-
-			if (!channel.collaboratorIds.includes(me.id) && !iAmModerator) {
+			if (!( iAmModerator || channel.userId === me.id || channel.collaboratorIds.includes(me.id) )) {
 				throw new ApiError(meta.errors.accessDenied);
 			}
 


### PR DESCRIPTION
fix #17 

## What
issueを見ろ #17 

## Additional info (optional)
・サーバーAdminがチャンネルを編集できる。
・チャンネル所有者がチャンネルを編集できる。
・チャンネル共同管理者がチャンネルを編集できる。
・一般ユーザーがチャンネルを編集できない。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
