### PR TITLE
update:channels/updateで共同編集者が共同編集者を編集できないように

### DIFF
--- a/packages/backend/src/server/api/endpoints/channels/update.ts
+++ b/packages/backend/src/server/api/endpoints/channels/update.ts
@@ -128,6 +128,10 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				})).map(u => u.id);
 			}
 
+			if ( !( channel.userId === me.id || iAmModerator ) ) {
+				collaboratorIds = channel.collaboratorIds;
+			};
+
 			const updateValues = {
 				...(ps.name !== undefined ? { name: ps.name } : {}),
 				...(ps.description !== undefined ? { description: ps.description } : {}),


### PR DESCRIPTION


## What
update #20 

## Additional info (optional)
・サーバーAdminがチャンネルを編集すると、共同管理者の更新が反映される。
・チャンネル所有者がチャンネルを編集すると、共同管理者の更新が反映される。
・チャンネル共同管理者がチャンネルを編集すると、共同管理者の更新が反映されず、更新前の内容のままになる。
・一般ユーザーがチャンネルを編集できない。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
