### PR TITLE
fix:channel管理者移譲時のポップアップ表示を、username(id名)にすることでnullが出ないようにする

### DIFF
--- a/packages/frontend/src/pages/channel-editor.vue
+++ b/packages/frontend/src/pages/channel-editor.vue
@@ -175,7 +175,7 @@ function transferAdmin() {
 		os.confirm({
 			type: 'warning',
 			title: i18n.ts._channel.transferAdminConfirmTitle,
-			text: i18n.tsx._channel.transferAdminConfirmDescription({ user: user.name }),
+			text: i18n.tsx._channel.transferAdminConfirmDescription({ user: user.username }),
 		}).then(({ canceled }) => {
 			if (canceled) return;
 			os.confirm({


### PR DESCRIPTION
## What
fix #34 

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
