### PR TITLE
fix: channel/updateを直接たたくと共同管理者がチャンネル所有権を奪えてしまう #38

### DIFF
--- a/packages/backend/src/server/api/endpoints/channels/update.ts
+++ b/packages/backend/src/server/api/endpoints/channels/update.ts
@@ -149,7 +149,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				await this.channelsRepository.update(channel.id, updateValues);
 			}
 
-			if (ps.transferAdminUserId) {
+			if (ps.transferAdminUserId && ( channel.userId === me.id || iAmModerator )) {
 				await this.channelsRepository.update(channel.id, {
 					userId: ps.transferAdminUserId,
 				});


### PR DESCRIPTION
## What
fix:38

## Additional info (optional)
・一般ユーザーの共同管理者がtransferAdminUserIdを入力しても無視する。
・チャンネル所有者とサーバーadminがtransferAdminUserIdを入力すると反映する。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
