### PR TITLE
fix:チャンネルの共同編集者を0名にできない問題を修正

### DIFF
--- a/packages/backend/src/server/api/endpoints/channels/update.ts
+++ b/packages/backend/src/server/api/endpoints/channels/update.ts
@@ -128,10 +128,6 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				})).map(u => u.id);
 			}
 
-			if ( !( channel.userId === me.id || iAmModerator ) ) {
-				collaboratorIds = channel.collaboratorIds;
-			};
-
 			const updateValues = {
 				...(ps.name !== undefined ? { name: ps.name } : {}),
 				...(ps.description !== undefined ? { description: ps.description } : {}),
@@ -142,7 +138,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				...(typeof ps.isSensitive === 'boolean' ? { isSensitive: ps.isSensitive } : {}),
 				...(typeof ps.allowRenoteToExternal === 'boolean' ? { allowRenoteToExternal: ps.allowRenoteToExternal } : {}),
 				...(typeof ps.isLocalOnly === 'boolean' ? { isLocalOnly: ps.isLocalOnly } : {}),
-				...(collaboratorIds.length > 0 ? { collaboratorIds: collaboratorIds } : {}),
+				...((ps.collaboratorIds !== undefined && ( channel.userId === me.id || iAmModerator )) ? { collaboratorIds: collaboratorIds } : {}),
 			};
 
 			if (Object.keys(updateValues).length > 0) {


### PR DESCRIPTION


## What
fix #50 

## Additional info (optional)
・サーバーAdminが共同管理者を0人にすると、共同管理者の更新が反映される。
・チャンネル所有者が共同管理者を0人にすると、共同管理者の更新が反映される。
・チャンネル共同管理者がチャンネルを編集すると、共同管理者の更新が反映されず、更新前の内容のままになる。
・一般ユーザーがチャンネルを編集できない。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
